### PR TITLE
Auto-adjust track 1's resolution based on framerate

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -351,6 +351,10 @@ function love.resize(w, h)
         config.height = h
         config.save()
     end
+
+    if currentGame and currentGame.resize then
+        currentGame:resize(w, h)
+    end
 end
 
 function love.update(dt)

--- a/src/main.lua
+++ b/src/main.lua
@@ -442,6 +442,10 @@ function love.update(dt)
         fps = frameCount/frameTime
         frameTime = 0
         frameCount = 0
+
+        if currentGame and currentGame.onFps then
+            currentGame:onFps(fps)
+        end
     end
 end
 

--- a/src/track1/RoamingEye.lua
+++ b/src/track1/RoamingEye.lua
@@ -245,6 +245,8 @@ function RoamingEye:draw()
         chargeColor = {self.chargeColor[1], self.chargeColor[2], self.chargeColor[3], self.chargeColor[4]*chargeAmount}
     end
 
+    love.graphics.push()
+    love.graphics.origin()
     self.canvas:renderTo(function()
         love.graphics.clear(0,0,0,0)
 
@@ -264,6 +266,7 @@ function RoamingEye:draw()
         end
 
     end)
+    love.graphics.pop()
 
     self.game.layers.overlay:renderTo(function()
         local alpha = 255

--- a/src/track1/init.lua
+++ b/src/track1/init.lua
@@ -1033,13 +1033,13 @@ function Game:draw()
     if self.layers.toneMap then
         util.mapShader(self.canvas, self.layers.toneMap,
             self.shaders.gaussToneMap, {
-                sampleRadius = {self.scale/1280, 0},
+                sampleRadius = {1/1280, 0},
                 lowCut = {0.7,0.7,0.7,0.7},
                 gamma = 4
             })
         self.layers.toneMap, self.layers.toneMapBack = util.mapShader(self.layers.toneMap, self.layers.toneMapBack,
             self.shaders.gaussBlur, {
-                sampleRadius = {0, self.scale/720}
+                sampleRadius = {0, 1/720}
             })
 
         self.canvas:renderTo(function()

--- a/src/track1/init.lua
+++ b/src/track1/init.lua
@@ -60,11 +60,12 @@ function Game:resize(w, h)
 end
 
 function Game:setScale(scale)
-    -- limit the resolution to 1080p (TODO: adapt based on framerate)
-    self.scale = math.min(1080/720, scale)
+    -- limit the resolution to 1440p (TODO: adapt based on framerate)
+    self.scale = math.min(2, scale)
 
-    local w = self.scale*1280
-    local h = self.scale*720
+    local w = math.floor(self.scale*1280 + 0.5)
+    local h = math.floor(w*720/1280)
+    print("Now rendering at " .. w .. "x" .. h)
 
     self.canvas = love.graphics.newCanvas(w, h)
 

--- a/src/track1/init.lua
+++ b/src/track1/init.lua
@@ -56,7 +56,12 @@ function Game:seekMusic(pos, timeOfs)
 end
 
 function Game:resize(w, h)
-    self.scale = math.min(w/1280, h/720)
+    self:setScale(math.min(w/1280, h/720))
+end
+
+function Game:setScale(scale)
+    -- limit the resolution to 1080p (TODO: adapt based on framerate)
+    self.scale = math.min(1080/720, scale)
 
     local w = self.scale*1280
     local h = self.scale*720


### PR DESCRIPTION
If the framerate drops below 45, it aggressively lowers the resolution to try to increase it to 60 (with a minimum resolution of 360p). If the framerate goes above 55, it gently ratchets the resolution up toward the display's 1:1 pixel resolution.

This could be a useful framework for stuff in general going forward; maybe the logic should move into the top-level controller eventually.